### PR TITLE
Fix: Set working directory for C++ binary execution

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -48,10 +48,14 @@ async function executeVectorForge(
   args: string[]
 ): Promise<any> {
   try {
-    const { stdout, stderr } = await execFileAsync(VECTORFORGE_BIN, [
-      command,
-      ...args,
-    ]);
+    // Set working directory to VectorForge root
+    const { stdout, stderr } = await execFileAsync(
+      VECTORFORGE_BIN,
+      [command, ...args],
+      {
+        cwd: join(__dirname, "../../"),
+      }
+    );
 
     if (stderr) {
       console.error("VectorForge stderr:", stderr);


### PR DESCRIPTION
Add 'cwd' option to execFileAsync to ensure the VectorForge C++ binary executes from the project root directory. This fixes path resolution issues when the MCP server is run from different locations.

Changes:
- server/src/index.ts: Add cwd parameter to executeVectorForge function
- Set cwd to VectorForge root (../../ from dist directory)

This ensures data/database.bin and other relative paths work correctly regardless of where the MCP server process is started from.